### PR TITLE
Refactor crawler to use urllib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
 # requirements.txt
-requests
-beautifulsoup4
-datasets
-huggingface_hub
-lxml


### PR DESCRIPTION
## Summary
- refactor crawler to avoid external packages
- implement simple HTML parsing and URL fetch logic
- push results with git instead of `datasets` library
- remove dependencies from requirements.txt

## Testing
- `python -m py_compile cvdr_crawler.py`
- `python cvdr_crawler.py --help`

------
https://chatgpt.com/codex/tasks/task_e_686272ef2aa48329995b51bdbf8aac11